### PR TITLE
Making minimum speed into a map setting

### DIFF
--- a/resources/[race]/race/modes/deadline.lua
+++ b/resources/[race]/race/modes/deadline.lua
@@ -7,6 +7,23 @@ deadlineBindsActive = false
 deadlineDrawLines = false -- Bool for late joiners, draw lines or not
 deadlineActivationTimer = {}
 
+addEvent("onMapStarting")
+addEventHandler("onMapStarting", root, function(mapInfo)
+    local res = getResourceFromName(mapInfo.resname)
+    local racemode = res and getResourceInfo(res, "racemode") or nil
+    if racemode and racemode == "deadline" then
+        local minSpeedSetting = getNumber(mapInfo.resname..'.deadline_minimumspeed', 70)
+        if minSpeedSetting ~= 70 then
+		outputDebugString ("Deadline: custom setting was loaded from map meta. minimumspeed = " ..minSpeedSetting.."")
+	end
+	changeMinimumSpeed(minSpeedSetting)
+    end
+end)
+
+function changeMinimumSpeed(value)
+	DeadlineOptions.minimumSpeed = tonumber(value)
+	clientCall(root, 'Deadline.receiveNewSettings', DeadlineOptions)
+end
 
 ------------------------
 -- Gameplay Variables Standards --


### PR DESCRIPTION
this allows mappers to change the hard coded minimum speed. now its a map setting and it can be changed by adding this line in the map meta:
<setting name="#deadline_minimumspeed" value="your number here" />

if left unspecified the minimum speed will be 70 as usual.

huge thanks to Citizen for helping me making this work.